### PR TITLE
Adding publish snd cli to GH registry workflow

### DIFF
--- a/.github/workflows/publish-binary.yaml
+++ b/.github/workflows/publish-binary.yaml
@@ -1,9 +1,7 @@
 name: Release Snd-cli binary
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'
+  workflow_dispatch
 
 permissions:
   contents: write


### PR DESCRIPTION
Part of https://github.com/SneaksAndData/terraform/issues/2407

## Scope
Adding workflow to publish Snd Cli docker images to GH registry
