### PR TITLE
Improve Go release workflow 

### DIFF
--- a/.github/workflows/publish-binary.yaml
+++ b/.github/workflows/publish-binary.yaml
@@ -25,7 +25,7 @@ jobs:
         with:
           distribution: goreleaser
           version: '~> v2'
-          args: release --clean --snapshot
+          args: release --clean
           workdir: ./cmd/snd-cli
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Part of https://github.com/SneaksAndData/terraform/issues/2407

Improving Go binary release workflow

Implemented:
- Specifying working directory for binary release