### PR TITLE
Customize go releaser build

### DIFF
--- a/.github/workflows/publish-binary.yaml
+++ b/.github/workflows/publish-binary.yaml
@@ -26,6 +26,5 @@ jobs:
           distribution: goreleaser
           version: '~> v2'
           args: release --clean
-          workdir: ./cmd/snd-cli
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,13 @@
+# .goreleaser.yaml
+version: 2
+builds:
+  - id: snd-cli
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    main: ./cmd/snd-cli
+    ldflags:
+      - -s -w -X "snd-cli/cmd.Version={{.Version}}"


### PR DESCRIPTION
Part of #102 

## Scope

Implemented:
- Release binaries only for darwin and linux
- Add ldflag for version to build process


## Checklist

- [x] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [x] Self-review done.
