### PR TITLE
Publish install script to assets and update upgrade script

### DIFF
--- a/.github/workflows/publish-binary.yaml
+++ b/.github/workflows/publish-binary.yaml
@@ -28,3 +28,13 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload install.sh as release asset
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ steps.goreleaser.outputs.upload_url }}
+          asset_path: scripts/install.sh
+          asset_name: install.sh
+          asset_content_type: application/x-sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains a command-line interface for internal and external serv
 ## Installation
 Retrieve installation script from GitHub
 ```bash
-curl -L -o checksum-latest.txt https://github.com/SneaksAndData/snd-cli-go/releases/latest/download/install.sh
+curl -L -o install.sh https://github.com/SneaksAndData/snd-cli-go/releases/latest/download/install.sh
 ```
 
 #### Grant execute permission

--- a/README.md
+++ b/README.md
@@ -1,13 +1,36 @@
 # Command-line interface for Sneaks & Data
 
 This repository contains a command-line interface for internal and external services used in Sneaks & Data.
+ 
+## Installation
+Retrieve installation script from GitHub
+```bash
+curl -L -o checksum-latest.txt https://github.com/SneaksAndData/snd-cli-go/releases/latest/download/install.sh
+```
 
-## Requirements
+#### Grant execute permission
+```bash
+chmod +x install.sh
+```
+
+#### Run the installation script
+##### Linux
+```bash
+./install.sh
+```
+##### macOS
+
+```bash
+sh ./install.sh
+```
+
+
+## Requirements (deprecated)
 
 To be able to retrieve the installation script and the cli binary you need to have Azure CLI installed. Instructions on
 how to install it can be found here https://learn.microsoft.com/en-us/cli/azure/install-azure-cli.
 
-## Installation
+## Installation (deprecated)
 #### Login into Azure
 ```bash
 az login

--- a/pkg/cmd/upgrade/scripts/upgrade.sh
+++ b/pkg/cmd/upgrade/scripts/upgrade.sh
@@ -1,15 +1,26 @@
 #!/bin/bash
 # Installation script for SnD CLI
 set -e
+REPO_OWNER="SneaksAndData"
+REPO_NAME="snd-cli-go"
+LATEST_RELEASE_TAG=$(curl --silent "https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/releases/latest" | jq -r .tag_name)
+
+VERSION=$(echo $LATEST_RELEASE_TAG | sed 's/^v//')
+BASE_BIN_NAME="snd-cli-go_$VERSION"
+
 echo "Determining target OS and architecture..."
 ARCH=$(uname -m)
-if [[ "$OSTYPE" =~ ^darwin  &&  "$ARCH" =~ arm64 ]]; then
-    bin_name=snd-darwin-arm64
+if [[ "$OSTYPE" =~ ^darwin ]]; then
+     if [[ "$ARCH" =~ arm64 ]]; then
+        asset_name="${BASE_BIN_NAME}_darwin_arm64.tar.gz"
+      elif [[ "$ARCH" =~ (amd64|x86_64|x64) ]]; then
+        asset_name="${BASE_BIN_NAME}_darwin_amd64.tar.gz"
+      fi
 elif [[ "$OSTYPE" =~ ^linux ]]; then
   if [[ "$ARCH" =~ arm64 ]]; then
-    bin_name=snd-linux-arm64
+    asset_name="${BASE_BIN_NAME}_linux_arm64.tar.gz"
   elif [[ "$ARCH" =~ (amd64|x86_64|x64) ]]; then
-    bin_name=snd-linux-amd64
+    asset_name="${BASE_BIN_NAME}_linux_amd64.tar.gz"
   fi
 else
     echo "Error: Unsupported OS type or architecture: $OSTYPE $ARCH "
@@ -18,29 +29,20 @@ fi
 echo "Target OS: $OSTYPE"
 echo "Target ARCH: $ARCH"
 
-BUNDLE_URL="https://esddatalakeproduction.blob.core.windows.net/dist/snd-cli-go/$bin_name"
+BUNDLE_URL="https://github.com/$REPO_OWNER/$REPO_NAME/releases/download/$LATEST_RELEASE_TAG/$asset_name"
 
 # Define base path for the application
 base_path="$HOME/.local/snd-cli"
 mkdir -p "$base_path"
 
-# Check if az cli is installed
-echo "Check if Azure CLI is installed..."
-if ! command -v az &> /dev/null
-then
-    echo "az cli is not installed. Please install it from https://docs.microsoft.com/en-us/cli/azure/install-azure-cli"
-    exit
-fi
-
-# Login into azure
-echo "Please log in to Azure..."
-az login
-
 echo "Downloading the binary from $BUNDLE_URL"
 # Get file
-az storage blob download --blob-url $BUNDLE_URL --auth-mode login --file "$base_path/$bin_name"
+curl -L -o "$base_path/$asset_name" "$BUNDLE_URL"
 
-chmod +x "$base_path/$bin_name"
+echo "Extracting the binary..."
+tar -xzf "$base_path/$asset_name" -C "$base_path"
+
+chmod +x "$base_path/snd-cli-go"
 
 if [ -e "$HOME/.local/bin/snd" ]; then
    echo "Removing symlink..."
@@ -49,7 +51,7 @@ fi
 
 # Create a symbolic link to the application
 echo "Creating the symlink..."
-ln -s "$base_path/$bin_name" "$HOME/.local/bin/snd"
+ln -s "$base_path/snd-cli-go" "$HOME/.local/bin/snd"
 
 echo "Please restart your terminal for the changes to take effect."
 echo "After restarting, you can try running 'snd --help'. :)"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,19 +1,28 @@
 #!/bin/bash
 # Installation script for SnD CLI
 set -e
+
+# Define the URL for the GitHub release asset
+REPO_OWNER="SneaksAndData"
+REPO_NAME="snd-cli-go"
+LATEST_RELEASE_TAG=$(curl --silent "https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/releases/latest" | jq -r .tag_name)
+
+VERSION=$(echo $LATEST_RELEASE_TAG | sed 's/^v//')
+BASE_BIN_NAME="snd-cli-go_$VERSION"
+
 echo "Determining target OS and architecture..."
 ARCH=$(uname -m)
 if [[ "$OSTYPE" =~ ^darwin ]]; then
      if [[ "$ARCH" =~ arm64 ]]; then
-        bin_name=snd-darwin-arm64
+        asset_name="${BASE_BIN_NAME}_darwin_arm64.tar.gz"
       elif [[ "$ARCH" =~ (amd64|x86_64|x64) ]]; then
-        bin_name=snd-darwin-amd64
+        asset_name="${BASE_BIN_NAME}_darwin_amd64.tar.gz"
       fi
 elif [[ "$OSTYPE" =~ ^linux ]]; then
   if [[ "$ARCH" =~ arm64 ]]; then
-    bin_name=snd-linux-arm64
+    asset_name="${BASE_BIN_NAME}_linux_arm64.tar.gz"
   elif [[ "$ARCH" =~ (amd64|x86_64|x64) ]]; then
-    bin_name=snd-linux-amd64
+    asset_name="${BASE_BIN_NAME}_linux_amd64.tar.gz"
   fi
 else
     echo "Error: Unsupported OS type or architecture: $OSTYPE $ARCH "
@@ -22,29 +31,19 @@ fi
 echo "Target OS: $OSTYPE"
 echo "Target ARCH: $ARCH"
 
-BUNDLE_URL="https://esddatalakeproduction.blob.core.windows.net/dist/snd-cli-go/$bin_name"
-
+BUNDLE_URL="https://github.com/$REPO_OWNER/$REPO_NAME/releases/download/$LATEST_RELEASE_TAG/$asset_name"
 # Define base path for the application
 base_path="$HOME/.local/snd-cli"
 mkdir -p "$base_path"
 
-# Check if az cli is installed
-echo "Check if Azure CLI is installed..."
-if ! command -v az &> /dev/null
-then
-    echo "az cli is not installed. Please install it from https://docs.microsoft.com/en-us/cli/azure/install-azure-cli"
-    exit
-fi
-
-# Login into azure
-echo "Please log in to Azure..."
-az login
-
 echo "Downloading the binary from $BUNDLE_URL"
 # Get file
-az storage blob download --blob-url $BUNDLE_URL --auth-mode login --file "$base_path/$bin_name"
+curl -L -o "$base_path/$asset_name" "$BUNDLE_URL"
 
-chmod +x "$base_path/$bin_name"
+echo "Extracting the binary..."
+tar -xzf "$base_path/$asset_name" -C "$base_path"
+
+chmod +x "$base_path/snd-cli-go"
 
 if [ -e "$HOME/.local/bin/snd" ]; then
    echo "Removing symlink..."
@@ -53,7 +52,7 @@ fi
 
 # Create a symbolic link to the application
 echo "Creating the symlink..."
-ln -s "$base_path/$bin_name" "$HOME/.local/bin/snd"
+ln -s "$base_path/snd-cli-go" "$HOME/.local/bin/snd"
 
 echo "Please restart your terminal for the changes to take effect."
 echo "After restarting, you can try running 'snd --help'. :)"


### PR DESCRIPTION
Part of #102 

## Scope

Implemented:
- Publish `install.sh` script to assets
- Update `upgrade.sh` script to retrieve latest binary from gh assets

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Self-review done.
