### PR TITLE
Allow providing configurations for the Nexus from separate files

### DIFF
--- a/pkg/cmd/nexus/nexus_run_command.go
+++ b/pkg/cmd/nexus/nexus_run_command.go
@@ -26,7 +26,7 @@ func NewCmdRun(authServiceFactory *cmdutil.AuthServiceFactory, serviceFactory cm
 	cmd := &cobra.Command{
 		Use:   "run",
 		Short: heredoc.Doc(`Run a Nexus algorithm. The payload should be provided as a valid JSON file. In addition, configuration overrides, parent reference and validity period could be overridden.`),
-		Long: heredoc.Doc(`Run a Nexus algorithm. The payload should be provided as a valid JSON file. In addition, configuration overrides, parent reference and validity period could be overridden.	
+		Long: heredoc.Doc(`Run a Nexus algorithm. The payload should be provided as a valid JSON file. In addition, configuration overrides, parent reference and validity period could be overridden.
 Custom configuration format is provided here: https://github.com/SneaksAndData/nexus-sdk-go/blob/main/pkg/generated/scheduler/oas_schemas_gen.go#L1062-L1069. Example for a version override: {"container": {"versionTag": "v1.2.0"}}
 `),
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## Scope

- Split payload into several input arguments, to allow provided payload, custom config and parent reference independently
- Added new flags to the `nexus run` command: `--custom-configuration`, `--parent-request`, `--valid-for`, and `--tag`, enabling users to customize algorithm runs with configuration overrides, parent request references, validity period, and client-side tags.
