### PR TITLE
Don't use the distroless image

### DIFF
--- a/.container/Dockerfile
+++ b/.container/Dockerfile
@@ -43,7 +43,7 @@ RUN apt-get update \
  && apt-get --assume-yes upgrade \
  && apt-get --no-install-recommends --assume-yes install ca-certificates curl jq unzip apt-transport-https lsb-release gnupg libc-bin binutils wget
 
-COPY --from=build-stage /app /app
+COPY --from=build-stage /snd /app
 
 COPY --from=aws-cli-stage /usr/local/aws-cli/ /usr/local/aws-cli/
 COPY --from=aws-cli-stage /aws-cli-bin/ /usr/local/bin/


### PR DESCRIPTION
Use the old image for the import-resources container.

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [x] Self-review done.
